### PR TITLE
State Widths used in Frontend by Profile.js to store Space used by ea…

### DIFF
--- a/frontend/src/components/profile/Profile.js
+++ b/frontend/src/components/profile/Profile.js
@@ -45,7 +45,7 @@ function Profile() {
   const [user, setUser] = useState(null);
   const { darkMode, setDarkMode } = useDarkMode();
   const [mode, setMode] = useState({});
-  const [Widths, setWidths] = useState({});
+  const [Widths, setWidths] = useState([]);
 
 
   let currentWidth = 0;


### PR DESCRIPTION
…ch profile and left on the device was intialized as an object and not as an array -> if not initialized it crashed on the map function